### PR TITLE
Fix issues with converting ShaderConductor::MacroDefine

### DIFF
--- a/Source/Core/ShaderConductor.cpp
+++ b/Source/Core/ShaderConductor.cpp
@@ -309,6 +309,9 @@ namespace
 
         std::vector<DxcDefine> dxcDefines;
         std::vector<std::wstring> dxcDefineStrings;
+        // Need to reserve capacity so that small-string optimization does not
+        // invalidate the pointers to internal string data while resizing.
+        dxcDefineStrings.reserve(source.defines.size() * 2);
         for (const auto& define : source.defines)
         {
             std::wstring nameUtf16Str;
@@ -317,7 +320,7 @@ namespace
             const wchar_t* nameUtf16 = dxcDefineStrings.back().c_str();
 
             const wchar_t* valueUtf16;
-            if (define.value.empty())
+            if (!define.value.empty())
             {
                 std::wstring valueUtf16Str;
                 Unicode::UTF8ToUTF16String(define.value.c_str(), &valueUtf16Str);

--- a/Source/Tests/Data/Expected/Particle_GS.300.essl
+++ b/Source/Tests/Data/Expected/Particle_GS.300.essl
@@ -3,8 +3,8 @@
 layout(points) in;
 layout(max_vertices = 4, triangle_strip) out;
 
-const vec3 _42[4] = vec3[](vec3(-1.0, 1.0, 0.0), vec3(1.0, 1.0, 0.0), vec3(-1.0, -1.0, 0.0), vec3(1.0, -1.0, 0.0));
-const vec2 _47[4] = vec2[](vec2(0.0, 1.0), vec2(1.0), vec2(0.0), vec2(1.0, 0.0));
+const vec3 _43[4] = vec3[](vec3(-1.0, 1.0, 0.0), vec3(1.0, 1.0, 0.0), vec3(-1.0, -1.0, 0.0), vec3(1.0, -1.0, 0.0));
+const vec2 _48[4] = vec2[](vec2(0.0, 1.0), vec2(1.0), vec2(0.0), vec2(1.0, 0.0));
 
 layout(std140) uniform type_cbMain
 {
@@ -17,12 +17,12 @@ out vec2 out_var_TEXCOORD0;
 
 void main()
 {
-    for (int _54 = 0; _54 < 4; )
+    for (int _55 = 0; _55 < 4; )
     {
-        gl_Position = cbMain.viewProj * vec4((mat3(cbMain.invView[0].xyz, cbMain.invView[1].xyz, cbMain.invView[2].xyz) * (_42[_54] * 1.0)) + in_var_POSITION[0].xyz, 1.0);
-        out_var_TEXCOORD0 = _47[_54];
+        gl_Position = cbMain.viewProj * vec4((mat3(cbMain.invView[0].xyz, cbMain.invView[1].xyz, cbMain.invView[2].xyz) * (_43[_55] * 5.0)) + in_var_POSITION[0].xyz, 1.0);
+        out_var_TEXCOORD0 = _48[_55];
         EmitVertex();
-        _54++;
+        _55++;
         continue;
     }
     EndPrimitive();

--- a/Source/Tests/Data/Expected/Particle_GS.300.glsl
+++ b/Source/Tests/Data/Expected/Particle_GS.300.glsl
@@ -8,8 +8,8 @@ out gl_PerVertex
     vec4 gl_Position;
 };
 
-const vec3 _42[4] = vec3[](vec3(-1.0, 1.0, 0.0), vec3(1.0, 1.0, 0.0), vec3(-1.0, -1.0, 0.0), vec3(1.0, -1.0, 0.0));
-const vec2 _47[4] = vec2[](vec2(0.0, 1.0), vec2(1.0), vec2(0.0), vec2(1.0, 0.0));
+const vec3 _43[4] = vec3[](vec3(-1.0, 1.0, 0.0), vec3(1.0, 1.0, 0.0), vec3(-1.0, -1.0, 0.0), vec3(1.0, -1.0, 0.0));
+const vec2 _48[4] = vec2[](vec2(0.0, 1.0), vec2(1.0), vec2(0.0), vec2(1.0, 0.0));
 
 layout(std140) uniform type_cbMain
 {
@@ -22,12 +22,12 @@ layout(location = 0) out vec2 out_var_TEXCOORD0;
 
 void main()
 {
-    for (int _54 = 0; _54 < 4; )
+    for (int _55 = 0; _55 < 4; )
     {
-        gl_Position = cbMain.viewProj * vec4((mat3(cbMain.invView[0].xyz, cbMain.invView[1].xyz, cbMain.invView[2].xyz) * (_42[_54] * 1.0)) + in_var_POSITION[0].xyz, 1.0);
-        out_var_TEXCOORD0 = _47[_54];
+        gl_Position = cbMain.viewProj * vec4((mat3(cbMain.invView[0].xyz, cbMain.invView[1].xyz, cbMain.invView[2].xyz) * (_43[_55] * 5.0)) + in_var_POSITION[0].xyz, 1.0);
+        out_var_TEXCOORD0 = _48[_55];
         EmitVertex();
-        _54++;
+        _55++;
         continue;
     }
     EndPrimitive();

--- a/Source/Tests/Data/Expected/Particle_GS.310.essl
+++ b/Source/Tests/Data/Expected/Particle_GS.310.essl
@@ -3,8 +3,8 @@
 layout(points) in;
 layout(max_vertices = 4, triangle_strip) out;
 
-const vec3 _42[4] = vec3[](vec3(-1.0, 1.0, 0.0), vec3(1.0, 1.0, 0.0), vec3(-1.0, -1.0, 0.0), vec3(1.0, -1.0, 0.0));
-const vec2 _47[4] = vec2[](vec2(0.0, 1.0), vec2(1.0), vec2(0.0), vec2(1.0, 0.0));
+const vec3 _43[4] = vec3[](vec3(-1.0, 1.0, 0.0), vec3(1.0, 1.0, 0.0), vec3(-1.0, -1.0, 0.0), vec3(1.0, -1.0, 0.0));
+const vec2 _48[4] = vec2[](vec2(0.0, 1.0), vec2(1.0), vec2(0.0), vec2(1.0, 0.0));
 
 layout(binding = 0, std140) uniform type_cbMain
 {
@@ -17,12 +17,12 @@ layout(location = 0) out vec2 out_var_TEXCOORD0;
 
 void main()
 {
-    for (int _54 = 0; _54 < 4; )
+    for (int _55 = 0; _55 < 4; )
     {
-        gl_Position = cbMain.viewProj * vec4((mat3(cbMain.invView[0].xyz, cbMain.invView[1].xyz, cbMain.invView[2].xyz) * (_42[_54] * 1.0)) + in_var_POSITION[0].xyz, 1.0);
-        out_var_TEXCOORD0 = _47[_54];
+        gl_Position = cbMain.viewProj * vec4((mat3(cbMain.invView[0].xyz, cbMain.invView[1].xyz, cbMain.invView[2].xyz) * (_43[_55] * 5.0)) + in_var_POSITION[0].xyz, 1.0);
+        out_var_TEXCOORD0 = _48[_55];
         EmitVertex();
-        _54++;
+        _55++;
         continue;
     }
     EndPrimitive();

--- a/Source/Tests/Data/Expected/Particle_GS.410.glsl
+++ b/Source/Tests/Data/Expected/Particle_GS.410.glsl
@@ -7,8 +7,8 @@ out gl_PerVertex
     vec4 gl_Position;
 };
 
-const vec3 _42[4] = vec3[](vec3(-1.0, 1.0, 0.0), vec3(1.0, 1.0, 0.0), vec3(-1.0, -1.0, 0.0), vec3(1.0, -1.0, 0.0));
-const vec2 _47[4] = vec2[](vec2(0.0, 1.0), vec2(1.0), vec2(0.0), vec2(1.0, 0.0));
+const vec3 _43[4] = vec3[](vec3(-1.0, 1.0, 0.0), vec3(1.0, 1.0, 0.0), vec3(-1.0, -1.0, 0.0), vec3(1.0, -1.0, 0.0));
+const vec2 _48[4] = vec2[](vec2(0.0, 1.0), vec2(1.0), vec2(0.0), vec2(1.0, 0.0));
 
 layout(std140) uniform type_cbMain
 {
@@ -21,12 +21,12 @@ layout(location = 0) out vec2 out_var_TEXCOORD0;
 
 void main()
 {
-    for (int _54 = 0; _54 < 4; )
+    for (int _55 = 0; _55 < 4; )
     {
-        gl_Position = cbMain.viewProj * vec4((mat3(cbMain.invView[0].xyz, cbMain.invView[1].xyz, cbMain.invView[2].xyz) * (_42[_54] * 1.0)) + in_var_POSITION[0].xyz, 1.0);
-        out_var_TEXCOORD0 = _47[_54];
+        gl_Position = cbMain.viewProj * vec4((mat3(cbMain.invView[0].xyz, cbMain.invView[1].xyz, cbMain.invView[2].xyz) * (_43[_55] * 5.0)) + in_var_POSITION[0].xyz, 1.0);
+        out_var_TEXCOORD0 = _48[_55];
         EmitVertex();
-        _54++;
+        _55++;
         continue;
     }
     EndPrimitive();


### PR DESCRIPTION
* Fix unsafe access to internal wstring data which can be invalidated if
the wstring is moved due to small-string optimization where the string
data is stored internally instead of allocated.
* Fix logical inversion when converting defines with no value.