### PR TITLE
Explicitly pick Python 3 to avoid a conflict on macOS

### DIFF
--- a/CI/AzurePipelines/ContinuousBuild.yml
+++ b/CI/AzurePipelines/ContinuousBuild.yml
@@ -7,6 +7,12 @@ steps:
     git config --global user.name "Dummy Name"
   displayName: 'Config git'
 
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: '3.x'
+    addToPath: true
+    architecture: 'x64'
+
 - task: PythonScript@0
   displayName: 'Build'
   inputs:


### PR DESCRIPTION
Try to fix the CI failure on macOS.