### PR TITLE
Fix ShaderModel bitfield issue

### DIFF
--- a/Include/ShaderConductor/ShaderConductor.hpp
+++ b/Include/ShaderConductor/ShaderConductor.hpp
@@ -126,12 +126,12 @@ namespace ShaderConductor
     public:
         struct ShaderModel
         {
-            uint8_t major_ver : 6;
-            uint8_t minor_ver : 2;
+            uint8_t major_ver;
+            uint8_t minor_ver;
 
-            uint32_t FullVersion() const noexcept
+            uint16_t FullVersion() const noexcept
             {
-                return (major_ver << 2) | minor_ver;
+                return (major_ver << 8) | minor_ver;
             }
 
             bool operator<(const ShaderModel& other) const noexcept


### PR DESCRIPTION
https://github.com/microsoft/ShaderConductor/blob/30a77c78d24fa08f4fe5fc4428f10dbfc92717a6/Include/ShaderConductor/ShaderConductor.hpp#L130
Currently, the minor version number of the shader model cannot be set gerater than 3.
Fixed to be able to set the shader model currently provided by disabling the bitfield.