### PR TITLE
Fixed gcc 11.1 compilation errors

### DIFF
--- a/Include/ShaderConductor/ShaderConductor.hpp
+++ b/Include/ShaderConductor/ShaderConductor.hpp
@@ -29,6 +29,7 @@
 #pragma once
 
 #include <functional>
+#include <stdint.h>
 
 #if defined(__clang__)
 #define SC_SYMBOL_EXPORT __attribute__((__visibility__("default")))

--- a/Source/Core/ShaderConductor.cpp
+++ b/Source/Core/ShaderConductor.cpp
@@ -274,7 +274,7 @@ namespace
     private:
         std::function<Blob(const char* includeName)> m_loadCallback;
 
-        std::atomic<ULONG> m_ref = 0;
+        std::atomic<ULONG> m_ref = {0};
     };
 
     Blob DefaultLoadCallback(const char* includeName)


### PR DESCRIPTION
**Arch Linux x86_64 - gcc 11.0.0 x86_64-pc-linux-gnu**

ShaderConductor.hpp uses `uint*_t` types but hasn't included `stdint.h`
ShaderConductor.cpp has `std::atomic<ULONG> m_ref = 0;` which gives:
 `error: use of deleted function 'std::atomic<long unsigned int>::atomic(const std::atomic<long unsigned int>&)'`

[Use of deleted function with std::atomic](https://stackoverflow.com/questions/27314485/use-of-deleted-function-error-with-stdatomic-int)