### PR TITLE
VS2022 support

### DIFF
--- a/BuildAll.py
+++ b/BuildAll.py
@@ -64,6 +64,9 @@ def FindVS2017OrUpFolder(programFilesFolder, vsVersion, vsName):
 	LogError("Could NOT find VS%s.\n" % vsName)
 	return ""
 
+def FindVS2022Folder(programFilesFolder):
+	return FindVS2017OrUpFolder(programFilesFolder, 17, "2022")
+
 def FindVS2019Folder(programFilesFolder):
 	return FindVS2017OrUpFolder(programFilesFolder, 16, "2019")
 
@@ -132,7 +135,9 @@ def Build(hostPlatform, hostArch, buildSys, compiler, arch, configuration, tblge
 	batCmd = BatchCommand(hostPlatform)
 	if hostPlatform == "win":
 		programFilesFolder = FindProgramFilesFolder()
-		if (buildSys == "vs2019") or ((buildSys == "ninja") and (compiler == "vc142")):
+		if (buildSys == "vs2022") or ((buildSys == "ninja") and (compiler == "vc143")):
+			vsFolder = FindVS2022Folder(programFilesFolder)
+		elif (buildSys == "vs2019") or ((buildSys == "ninja") and (compiler == "vc142")):
 			vsFolder = FindVS2019Folder(programFilesFolder)
 		elif (buildSys == "vs2017") or ((buildSys == "ninja") and (compiler == "vc141")):
 			vsFolder = FindVS2017Folder(programFilesFolder)
@@ -153,10 +158,13 @@ def Build(hostPlatform, hostArch, buildSys, compiler, arch, configuration, tblge
 		else:
 			LogError("Unsupported architecture.\n")
 		vcToolset = ""
-		if (buildSys == "vs2019") and (compiler == "vc141"):
+		if (buildSys == "vs2022") and (compiler == "vc142"):
+			vcOption += " -vcvars_ver=14.2"
+			vcToolset = "v142,"
+		elif ((buildSys == "vs2022") or (buildSys == "vs2019")) and (compiler == "vc141"):
 			vcOption += " -vcvars_ver=14.1"
 			vcToolset = "v141,"
-		elif ((buildSys == "vs2019") or (buildSys == "vs2017")) and (compiler == "vc140"):
+		elif ((buildSys == "vs2022") or (buildSys == "vs2019") or (buildSys == "vs2017")) and (compiler == "vc140"):
 			vcOption += " -vcvars_ver=14.0"
 			vcToolset = "v140,"
 		batCmd.AddCommand("@call \"%sVCVARSALL.BAT\" %s" % (vsFolder, vcOption))
@@ -176,7 +184,9 @@ def Build(hostPlatform, hostArch, buildSys, compiler, arch, configuration, tblge
 		else:
 			batCmd.AddCommand("ninja -j%d" % parallel)
 	else:
-		if buildSys == "vs2019":
+		if buildSys == "vs2022":
+			generator = "\"Visual Studio 17\""
+		elif buildSys == "vs2019":
 			generator = "\"Visual Studio 16\""
 		elif buildSys == "vs2017":
 			generator = "\"Visual Studio 15\""
@@ -240,7 +250,9 @@ if __name__ == "__main__":
 	if (argc > 2):
 		compiler = sys.argv[2]
 	else:
-		if buildSys == "vs2019":
+		if buildSys == "vs2022":
+			compiler = "vc143"
+		elif buildSys == "vs2019":
 			compiler = "vc142"
 		elif buildSys == "vs2017":
 			compiler = "vc141"

--- a/CI/AzurePipelines/ContinuousBuild.yml
+++ b/CI/AzurePipelines/ContinuousBuild.yml
@@ -7,6 +7,12 @@ steps:
     git config --global user.name "Dummy Name"
   displayName: 'Config git'
 
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: '3.x'
+    addToPath: true
+    architecture: 'x64'
+
 - task: PythonScript@0
   displayName: 'Build'
   inputs:

--- a/External/CMakeLists.txt
+++ b/External/CMakeLists.txt
@@ -1,6 +1,10 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+if(NOT EXISTS ${git_executable})
+    unset(git_executable CACHE)
+endif()
+
 find_program(git_executable NAMES git git.exe git.cmd)
 if(NOT git_executable)
     message(FATAL_ERROR "Failed to find git.")

--- a/External/DirectXShaderCompiler.cmake
+++ b/External/DirectXShaderCompiler.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-set(DirectXShaderCompiler_REV "634a23537df7e85512437a4976f9bf9fcd095e18")
+set(DirectXShaderCompiler_REV "cc50c79df1272a358fbf8b16e85dc6a9e5bc2ead")
 
 UpdateExternalLib("DirectXShaderCompiler" "https://github.com/Microsoft/DirectXShaderCompiler.git" ${DirectXShaderCompiler_REV})
 
@@ -40,6 +40,7 @@ endif()
 set(SPIRV_BUILD_TESTS OFF CACHE BOOL "" FORCE)
 set(SPIRV_SKIP_EXECUTABLES ON CACHE BOOL "" FORCE)
 set(SPIRV_SKIP_TESTS ON CACHE BOOL "" FORCE)
+
 add_subdirectory(DirectXShaderCompiler EXCLUDE_FROM_ALL)
 foreach(target
     "clang" "dxc"
@@ -53,9 +54,12 @@ foreach(target
     "ClangDiagnosticAnalysis" "ClangDiagnosticAST" "ClangDiagnosticComment" "ClangDiagnosticCommon" "ClangDiagnosticDriver"
     "ClangDiagnosticFrontend" "ClangDiagnosticGroups" "ClangDiagnosticIndexName" "ClangDiagnosticLex" "ClangDiagnosticParse"
     "ClangDiagnosticSema" "ClangDiagnosticSerialization" "ClangStmtNodes"
-    "LLVMAnalysis" "LLVMAsmParser" "LLVMBitReader" "LLVMBitWriter" "LLVMCore" "LLVMDxcSupport" "LLVMDXIL" "LLVMDxilContainer"
+    "DxcDisassembler" "DxcOptimizer" "DxilConstants" "DxilCounters" "DxilDocs" "DxilInstructions" "DxilIntrinsicTables"
+    "DxilMetadata" "DxilOperations" "DxilPIXPasses" "DxilShaderModel" "DxilShaderModelInc" "DxilSigPoint" "DxilValidation" "DxilValidationInc"
+    "HCTGen" "HLSLIntrinsicOp" "HLSLOptions"
+    "LLVMAnalysis" "LLVMAsmParser" "LLVMBitReader" "LLVMBitWriter" "LLVMCore" "LLVMDxcBindingTable" "LLVMDxcSupport" "LLVMDXIL" "LLVMDxilContainer"
     "LLVMDxilPIXPasses" "LLVMDxilRootSignature" "LLVMDxrFallback" "LLVMHLSL" "LLVMInstCombine" "LLVMipa" "LLVMipo" "LLVMIRReader"
-    "LLVMLinker" "LLVMLTO" "LLVMMSSupport" "LLVMOption" "LLVMPasses" "LLVMPassPrinters" "LLVMProfileData" "LLVMScalarOpts" "LLVMSupport"
+    "LLVMLinker" "LLVMMiniz" "LLVMMSSupport" "LLVMOption" "LLVMPasses" "LLVMPassPrinters" "LLVMProfileData" "LLVMScalarOpts" "LLVMSupport"
     "LLVMTableGen" "LLVMTarget" "LLVMTransformUtils" "LLVMVectorize"
     "ClangDriverOptions" "DxcEtw" "intrinsics_gen" "TablegenHLSLOptions"
     "clang-tblgen" "llvm-tblgen" "hlsl_dxcversion_autogen" "hlsl_version_autogen")

--- a/External/SPIRV-Cross.cmake
+++ b/External/SPIRV-Cross.cmake
@@ -1,9 +1,11 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-set(SPIRV_Cross_REV "8891bd35120ca91c252a66ccfdc3f9a9d03c70cd")
+set(SPIRV_Cross_REV "37dfb3f45f4fc47c841f81e618c602f6f3de0f17")
 
 UpdateExternalLib("SPIRV-Cross" "https://github.com/KhronosGroup/SPIRV-Cross.git" ${SPIRV_Cross_REV})
+
+set(SPIRV_CROSS_ENABLE_TESTS OFF CACHE BOOL "" FORCE)
 
 add_subdirectory(SPIRV-Cross EXCLUDE_FROM_ALL)
 foreach(target

--- a/External/SPIRV-Header.cmake
+++ b/External/SPIRV-Header.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-set(SPIRV_Headers_REV "3fdabd0da2932c276b25b9b4a988ba134eba1aa6")
+set(SPIRV_Headers_REV "29817199b7069bac971e5365d180295d4b077ebe")
 
 UpdateExternalLib("SPIRV-Headers" "https://github.com/KhronosGroup/SPIRV-Headers.git" ${SPIRV_Headers_REV})
 

--- a/External/SPIRV-Tools.cmake
+++ b/External/SPIRV-Tools.cmake
@@ -1,19 +1,29 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-set(SPIRV_Tools_REV "c341f7a6cd441d05ca1347ee39f2f03f32225c59")
+set(SPIRV_Tools_REV "1589720e1065bd163fb8e812f268413b13755f7c")
 
 UpdateExternalLib("SPIRV-Tools" "https://github.com/KhronosGroup/SPIRV-Tools.git" ${SPIRV_Tools_REV})
 
 set(SPIRV_SKIP_EXECUTABLES ON CACHE BOOL "" FORCE)
 add_subdirectory(SPIRV-Tools EXCLUDE_FROM_ALL)
+
+if(MSVC)
+    target_compile_options(SPIRV-Tools-static
+        PRIVATE
+            /wd4819
+    )
+endif()
+
 foreach(target
     "core_tables" "enum_string_mapping" "extinst_tables"
     "spirv-tools-pkg-config" "spirv-tools-shared-pkg-config"
     "spirv-tools-build-version" "spirv-tools-header-DebugInfo"
     "SPIRV-Tools-link" "SPIRV-Tools-shared"
-    "spirv-tools-header-OpenCLDebugInfo100" "spirv-tools-vimsyntax" "spv-tools-cldi100" "spv-tools-clspvreflection" "spv-tools-debuginfo" "spv-tools-spv-amd-gs"
-    "spv-tools-spv-amd-sb" "spv-tools-spv-amd-sevp" "spv-tools-spv-amd-stm")
+    "spirv-tools-header-OpenCLDebugInfo100" "spirv-tools-header-NonSemanticShaderDebugInfo100"
+    "spirv-tools-vimsyntax" "spv-tools-cldi100" "spv-tools-shdi100" "spv-tools-clspvreflection"
+    "spv-tools-debuginfo" "spv-tools-spv-amd-gs" "spv-tools-spv-amd-sb" "spv-tools-spv-amd-sevp"
+    "spv-tools-spv-amd-stm")
     get_target_property(vsFolder ${target} FOLDER)
     if(NOT vsFolder)
         set(vsFolder "")

--- a/Source/Tests/Data/Expected/CalcLight+Diffuse.Debug.dxilasm
+++ b/Source/Tests/Data/Expected/CalcLight+Diffuse.Debug.dxilasm
@@ -15,8 +15,8 @@
 ; -------------------- ----- ------ -------- -------- ------- ------
 ; SV_Target                0   xyzw        0   TARGET   float   xyzw
 ;
-; shader debug name: d81432b398a9151e6a076b6b827882eb.pdb
-; shader hash: d81432b398a9151e6a076b6b827882eb
+; shader debug name: 1c9ff017e8c534734cdc26123d89517a.pdb
+; shader hash: 1c9ff017e8c534734cdc26123d89517a
 ;
 ; Pipeline Runtime Information: 
 ;
@@ -45,14 +45,7 @@
 ; cbuffer cbPS
 ; {
 ;
-;   struct cbPS
-;   {
-;
-;       float3 diffColor;                             ; Offset:    0
-;       float3 specColor;                             ; Offset:   16
-;       float shininess;                              ; Offset:   28
-;   
-;   } cbPS;                                           ; Offset:    0 Size:    32
+;   [32 x i8] (type annotation not present)
 ;
 ; }
 ;
@@ -75,11 +68,8 @@
 ;
 target triple = "dxil-ms-dx"
 
-%cbPS = type { <3 x float>, <3 x float>, float }
 %dx.types.CBufRet.f32 = type { float, float, float, float }
 %dx.types.Handle = type { i8* }
-
-@cbPS = external constant %cbPS
 
 ; Function Attrs: nounwind readnone
 declare float @dx.op.loadInput.f32(i32, i32, i32, i8, i32) #0
@@ -135,37 +125,32 @@ attributes #2 = { nounwind }
 !dx.valver = !{!2}
 !dx.shaderModel = !{!3}
 !dx.resources = !{!4}
-!dx.typeAnnotations = !{!7, !12}
-!dx.viewIdState = !{!16}
-!dx.entryPoints = !{!17}
+!dx.typeAnnotations = !{!7}
+!dx.viewIdState = !{!11}
+!dx.entryPoints = !{!12}
 
 !0 = !{!"clang version 3.7 (tags/RELEASE_370/final)"}
 !1 = !{i32 1, i32 0}
-!2 = !{i32 1, i32 6}
+!2 = !{i32 1, i32 7}
 !3 = !{!"ps", i32 6, i32 0}
 !4 = !{null, null, !5, null}
 !5 = !{!6}
-!6 = !{i32 0, %cbPS* undef, !"cbPS", i32 0, i32 0, i32 1, i32 32, null}
-!7 = !{i32 0, %cbPS undef, !8}
-!8 = !{i32 32, !9, !10, !11}
-!9 = !{i32 6, !"diffColor", i32 3, i32 0, i32 7, i32 9}
-!10 = !{i32 6, !"specColor", i32 3, i32 16, i32 7, i32 9}
-!11 = !{i32 6, !"shininess", i32 3, i32 28, i32 7, i32 9}
-!12 = !{i32 1, void ()* @main, !13}
-!13 = !{!14}
-!14 = !{i32 0, !15, !15}
-!15 = !{}
-!16 = !{[17 x i32] [i32 15, i32 4, i32 0, i32 0, i32 0, i32 0, i32 7, i32 7, i32 7, i32 0, i32 7, i32 7, i32 7, i32 0, i32 0, i32 0, i32 0]}
-!17 = !{void ()* @main, !"main", !18, !4, null}
-!18 = !{!19, !27, null}
-!19 = !{!20, !22, !24, !25}
-!20 = !{i32 0, !"SV_Position", i8 9, i8 3, !21, i8 4, i32 1, i8 4, i32 0, i8 0, null}
-!21 = !{i32 0}
-!22 = !{i32 1, !"NORMAL", i8 9, i8 0, !21, i8 2, i32 1, i8 3, i32 1, i8 0, !23}
-!23 = !{i32 3, i32 7}
-!24 = !{i32 2, !"TEXCOORD", i8 9, i8 0, !21, i8 2, i32 1, i8 3, i32 2, i8 0, !23}
-!25 = !{i32 3, !"TEXCOORD", i8 9, i8 0, !26, i8 2, i32 1, i8 3, i32 3, i8 0, null}
-!26 = !{i32 1}
-!27 = !{!28}
-!28 = !{i32 0, !"SV_Target", i8 9, i8 16, !21, i8 0, i32 1, i8 4, i32 0, i8 0, !29}
-!29 = !{i32 3, i32 15}
+!6 = !{i32 0, %dx.types.Handle* undef, !"cbPS", i32 0, i32 0, i32 1, i32 32, null}
+!7 = !{i32 1, void ()* @main, !8}
+!8 = !{!9}
+!9 = !{i32 0, !10, !10}
+!10 = !{}
+!11 = !{[17 x i32] [i32 15, i32 4, i32 0, i32 0, i32 0, i32 0, i32 7, i32 7, i32 7, i32 0, i32 7, i32 7, i32 7, i32 0, i32 0, i32 0, i32 0]}
+!12 = !{void ()* @main, !"main", !13, !4, null}
+!13 = !{!14, !22, null}
+!14 = !{!15, !17, !19, !20}
+!15 = !{i32 0, !"SV_Position", i8 9, i8 3, !16, i8 4, i32 1, i8 4, i32 0, i8 0, null}
+!16 = !{i32 0}
+!17 = !{i32 1, !"NORMAL", i8 9, i8 0, !16, i8 2, i32 1, i8 3, i32 1, i8 0, !18}
+!18 = !{i32 3, i32 7}
+!19 = !{i32 2, !"TEXCOORD", i8 9, i8 0, !16, i8 2, i32 1, i8 3, i32 2, i8 0, !18}
+!20 = !{i32 3, !"TEXCOORD", i8 9, i8 0, !21, i8 2, i32 1, i8 3, i32 3, i8 0, null}
+!21 = !{i32 1}
+!22 = !{!23}
+!23 = !{i32 0, !"SV_Target", i8 9, i8 16, !16, i8 0, i32 1, i8 4, i32 0, i8 0, !24}
+!24 = !{i32 3, i32 15}

--- a/Source/Tests/Data/Expected/CalcLight+Diffuse.Release.dxilasm
+++ b/Source/Tests/Data/Expected/CalcLight+Diffuse.Release.dxilasm
@@ -15,8 +15,8 @@
 ; -------------------- ----- ------ -------- -------- ------- ------
 ; SV_Target                0   xyzw        0   TARGET   float   xyzw
 ;
-; shader debug name: ad90c6ff56d81fd333e64a2bf70453fc.pdb
-; shader hash: ad90c6ff56d81fd333e64a2bf70453fc
+; shader debug name: c247268630a3fe54e4153ff9c6dc82e1.pdb
+; shader hash: c247268630a3fe54e4153ff9c6dc82e1
 ;
 ; Pipeline Runtime Information: 
 ;
@@ -45,14 +45,7 @@
 ; cbuffer cbPS
 ; {
 ;
-;   struct cbPS
-;   {
-;
-;       float3 diffColor;                             ; Offset:    0
-;       float3 specColor;                             ; Offset:   16
-;       float shininess;                              ; Offset:   28
-;   
-;   } cbPS;                                           ; Offset:    0 Size:    32
+;   [32 x i8] (type annotation not present)
 ;
 ; }
 ;
@@ -75,11 +68,8 @@
 ;
 target triple = "dxil-ms-dx"
 
-%cbPS = type { <3 x float>, <3 x float>, float }
 %dx.types.CBufRet.f32 = type { float, float, float, float }
 %dx.types.Handle = type { i8* }
-
-@cbPS = external constant %cbPS
 
 ; Function Attrs: nounwind readnone
 declare float @dx.op.loadInput.f32(i32, i32, i32, i8, i32) #0
@@ -134,37 +124,32 @@ attributes #2 = { nounwind }
 !dx.valver = !{!2}
 !dx.shaderModel = !{!3}
 !dx.resources = !{!4}
-!dx.typeAnnotations = !{!7, !12}
-!dx.viewIdState = !{!16}
-!dx.entryPoints = !{!17}
+!dx.typeAnnotations = !{!7}
+!dx.viewIdState = !{!11}
+!dx.entryPoints = !{!12}
 
 !0 = !{!"clang version 3.7 (tags/RELEASE_370/final)"}
 !1 = !{i32 1, i32 0}
-!2 = !{i32 1, i32 6}
+!2 = !{i32 1, i32 7}
 !3 = !{!"ps", i32 6, i32 0}
 !4 = !{null, null, !5, null}
 !5 = !{!6}
-!6 = !{i32 0, %cbPS* undef, !"cbPS", i32 0, i32 0, i32 1, i32 32, null}
-!7 = !{i32 0, %cbPS undef, !8}
-!8 = !{i32 32, !9, !10, !11}
-!9 = !{i32 6, !"diffColor", i32 3, i32 0, i32 7, i32 9}
-!10 = !{i32 6, !"specColor", i32 3, i32 16, i32 7, i32 9}
-!11 = !{i32 6, !"shininess", i32 3, i32 28, i32 7, i32 9}
-!12 = !{i32 1, void ()* @main, !13}
-!13 = !{!14}
-!14 = !{i32 0, !15, !15}
-!15 = !{}
-!16 = !{[17 x i32] [i32 15, i32 4, i32 0, i32 0, i32 0, i32 0, i32 7, i32 7, i32 7, i32 0, i32 7, i32 7, i32 7, i32 0, i32 0, i32 0, i32 0]}
-!17 = !{void ()* @main, !"main", !18, !4, null}
-!18 = !{!19, !27, null}
-!19 = !{!20, !22, !24, !25}
-!20 = !{i32 0, !"SV_Position", i8 9, i8 3, !21, i8 4, i32 1, i8 4, i32 0, i8 0, null}
-!21 = !{i32 0}
-!22 = !{i32 1, !"NORMAL", i8 9, i8 0, !21, i8 2, i32 1, i8 3, i32 1, i8 0, !23}
-!23 = !{i32 3, i32 7}
-!24 = !{i32 2, !"TEXCOORD", i8 9, i8 0, !21, i8 2, i32 1, i8 3, i32 2, i8 0, !23}
-!25 = !{i32 3, !"TEXCOORD", i8 9, i8 0, !26, i8 2, i32 1, i8 3, i32 3, i8 0, null}
-!26 = !{i32 1}
-!27 = !{!28}
-!28 = !{i32 0, !"SV_Target", i8 9, i8 16, !21, i8 0, i32 1, i8 4, i32 0, i8 0, !29}
-!29 = !{i32 3, i32 15}
+!6 = !{i32 0, %dx.types.Handle* undef, !"cbPS", i32 0, i32 0, i32 1, i32 32, null}
+!7 = !{i32 1, void ()* @main, !8}
+!8 = !{!9}
+!9 = !{i32 0, !10, !10}
+!10 = !{}
+!11 = !{[17 x i32] [i32 15, i32 4, i32 0, i32 0, i32 0, i32 0, i32 7, i32 7, i32 7, i32 0, i32 7, i32 7, i32 7, i32 0, i32 0, i32 0, i32 0]}
+!12 = !{void ()* @main, !"main", !13, !4, null}
+!13 = !{!14, !22, null}
+!14 = !{!15, !17, !19, !20}
+!15 = !{i32 0, !"SV_Position", i8 9, i8 3, !16, i8 4, i32 1, i8 4, i32 0, i8 0, null}
+!16 = !{i32 0}
+!17 = !{i32 1, !"NORMAL", i8 9, i8 0, !16, i8 2, i32 1, i8 3, i32 1, i8 0, !18}
+!18 = !{i32 3, i32 7}
+!19 = !{i32 2, !"TEXCOORD", i8 9, i8 0, !16, i8 2, i32 1, i8 3, i32 2, i8 0, !18}
+!20 = !{i32 3, !"TEXCOORD", i8 9, i8 0, !21, i8 2, i32 1, i8 3, i32 3, i8 0, null}
+!21 = !{i32 1}
+!22 = !{!23}
+!23 = !{i32 0, !"SV_Target", i8 9, i8 16, !16, i8 0, i32 1, i8 4, i32 0, i8 0, !24}
+!24 = !{i32 3, i32 15}

--- a/Source/Tests/Data/Expected/CalcLight+DiffuseSpecular.Debug.dxilasm
+++ b/Source/Tests/Data/Expected/CalcLight+DiffuseSpecular.Debug.dxilasm
@@ -15,8 +15,8 @@
 ; -------------------- ----- ------ -------- -------- ------- ------
 ; SV_Target                0   xyzw        0   TARGET   float   xyzw
 ;
-; shader debug name: 65620ef187dc1e38cb91d8208665ef7d.pdb
-; shader hash: 65620ef187dc1e38cb91d8208665ef7d
+; shader debug name: 25518f9e3687a943487e772bc4f7808c.pdb
+; shader hash: 25518f9e3687a943487e772bc4f7808c
 ;
 ; Pipeline Runtime Information: 
 ;
@@ -45,14 +45,7 @@
 ; cbuffer cbPS
 ; {
 ;
-;   struct cbPS
-;   {
-;
-;       float3 diffColor;                             ; Offset:    0
-;       float3 specColor;                             ; Offset:   16
-;       float shininess;                              ; Offset:   28
-;   
-;   } cbPS;                                           ; Offset:    0 Size:    32
+;   [32 x i8] (type annotation not present)
 ;
 ; }
 ;
@@ -75,11 +68,8 @@
 ;
 target triple = "dxil-ms-dx"
 
-%cbPS = type { <3 x float>, <3 x float>, float }
 %dx.types.CBufRet.f32 = type { float, float, float, float }
 %dx.types.Handle = type { i8* }
-
-@cbPS = external constant %cbPS
 
 ; Function Attrs: nounwind readnone
 declare float @dx.op.loadInput.f32(i32, i32, i32, i8, i32) #0
@@ -181,37 +171,32 @@ attributes #2 = { nounwind }
 !dx.valver = !{!2}
 !dx.shaderModel = !{!3}
 !dx.resources = !{!4}
-!dx.typeAnnotations = !{!7, !12}
-!dx.viewIdState = !{!16}
-!dx.entryPoints = !{!17}
+!dx.typeAnnotations = !{!7}
+!dx.viewIdState = !{!11}
+!dx.entryPoints = !{!12}
 
 !0 = !{!"clang version 3.7 (tags/RELEASE_370/final)"}
 !1 = !{i32 1, i32 0}
-!2 = !{i32 1, i32 6}
+!2 = !{i32 1, i32 7}
 !3 = !{!"ps", i32 6, i32 0}
 !4 = !{null, null, !5, null}
 !5 = !{!6}
-!6 = !{i32 0, %cbPS* undef, !"cbPS", i32 0, i32 0, i32 1, i32 32, null}
-!7 = !{i32 0, %cbPS undef, !8}
-!8 = !{i32 32, !9, !10, !11}
-!9 = !{i32 6, !"diffColor", i32 3, i32 0, i32 7, i32 9}
-!10 = !{i32 6, !"specColor", i32 3, i32 16, i32 7, i32 9}
-!11 = !{i32 6, !"shininess", i32 3, i32 28, i32 7, i32 9}
-!12 = !{i32 1, void ()* @main, !13}
-!13 = !{!14}
-!14 = !{i32 0, !15, !15}
-!15 = !{}
-!16 = !{[17 x i32] [i32 15, i32 4, i32 0, i32 0, i32 0, i32 0, i32 7, i32 7, i32 7, i32 0, i32 7, i32 7, i32 7, i32 0, i32 7, i32 7, i32 7]}
-!17 = !{void ()* @main, !"main", !18, !4, null}
-!18 = !{!19, !27, null}
-!19 = !{!20, !22, !24, !25}
-!20 = !{i32 0, !"SV_Position", i8 9, i8 3, !21, i8 4, i32 1, i8 4, i32 0, i8 0, null}
-!21 = !{i32 0}
-!22 = !{i32 1, !"NORMAL", i8 9, i8 0, !21, i8 2, i32 1, i8 3, i32 1, i8 0, !23}
-!23 = !{i32 3, i32 7}
-!24 = !{i32 2, !"TEXCOORD", i8 9, i8 0, !21, i8 2, i32 1, i8 3, i32 2, i8 0, !23}
-!25 = !{i32 3, !"TEXCOORD", i8 9, i8 0, !26, i8 2, i32 1, i8 3, i32 3, i8 0, !23}
-!26 = !{i32 1}
-!27 = !{!28}
-!28 = !{i32 0, !"SV_Target", i8 9, i8 16, !21, i8 0, i32 1, i8 4, i32 0, i8 0, !29}
-!29 = !{i32 3, i32 15}
+!6 = !{i32 0, %dx.types.Handle* undef, !"cbPS", i32 0, i32 0, i32 1, i32 32, null}
+!7 = !{i32 1, void ()* @main, !8}
+!8 = !{!9}
+!9 = !{i32 0, !10, !10}
+!10 = !{}
+!11 = !{[17 x i32] [i32 15, i32 4, i32 0, i32 0, i32 0, i32 0, i32 7, i32 7, i32 7, i32 0, i32 7, i32 7, i32 7, i32 0, i32 7, i32 7, i32 7]}
+!12 = !{void ()* @main, !"main", !13, !4, null}
+!13 = !{!14, !22, null}
+!14 = !{!15, !17, !19, !20}
+!15 = !{i32 0, !"SV_Position", i8 9, i8 3, !16, i8 4, i32 1, i8 4, i32 0, i8 0, null}
+!16 = !{i32 0}
+!17 = !{i32 1, !"NORMAL", i8 9, i8 0, !16, i8 2, i32 1, i8 3, i32 1, i8 0, !18}
+!18 = !{i32 3, i32 7}
+!19 = !{i32 2, !"TEXCOORD", i8 9, i8 0, !16, i8 2, i32 1, i8 3, i32 2, i8 0, !18}
+!20 = !{i32 3, !"TEXCOORD", i8 9, i8 0, !21, i8 2, i32 1, i8 3, i32 3, i8 0, !18}
+!21 = !{i32 1}
+!22 = !{!23}
+!23 = !{i32 0, !"SV_Target", i8 9, i8 16, !16, i8 0, i32 1, i8 4, i32 0, i8 0, !24}
+!24 = !{i32 3, i32 15}

--- a/Source/Tests/Data/Expected/CalcLight+DiffuseSpecular.Release.dxilasm
+++ b/Source/Tests/Data/Expected/CalcLight+DiffuseSpecular.Release.dxilasm
@@ -15,8 +15,8 @@
 ; -------------------- ----- ------ -------- -------- ------- ------
 ; SV_Target                0   xyzw        0   TARGET   float   xyzw
 ;
-; shader debug name: 7f14de892298c5aa041b655c7a09b6e5.pdb
-; shader hash: 7f14de892298c5aa041b655c7a09b6e5
+; shader debug name: 98d2b1bcd83bf049601636cc5a9e1e37.pdb
+; shader hash: 98d2b1bcd83bf049601636cc5a9e1e37
 ;
 ; Pipeline Runtime Information: 
 ;
@@ -45,14 +45,7 @@
 ; cbuffer cbPS
 ; {
 ;
-;   struct cbPS
-;   {
-;
-;       float3 diffColor;                             ; Offset:    0
-;       float3 specColor;                             ; Offset:   16
-;       float shininess;                              ; Offset:   28
-;   
-;   } cbPS;                                           ; Offset:    0 Size:    32
+;   [32 x i8] (type annotation not present)
 ;
 ; }
 ;
@@ -75,11 +68,8 @@
 ;
 target triple = "dxil-ms-dx"
 
-%cbPS = type { <3 x float>, <3 x float>, float }
 %dx.types.CBufRet.f32 = type { float, float, float, float }
 %dx.types.Handle = type { i8* }
-
-@cbPS = external constant %cbPS
 
 ; Function Attrs: nounwind readnone
 declare float @dx.op.loadInput.f32(i32, i32, i32, i8, i32) #0
@@ -132,35 +122,35 @@ define void @main() {
   %.i06.i = fcmp fast ogt float %12, 0.000000e+00
   %.i17.i = fcmp fast ogt float %13, 0.000000e+00
   %.i28.i = fcmp fast ogt float %14, 0.000000e+00
-  %.i010.i = fsub fast float 1.000000e+00, %12
-  %.i112.i = fsub fast float 1.000000e+00, %13
-  %.i214.i = fsub fast float 1.000000e+00, %14
+  %.i09.i = fsub fast float 1.000000e+00, %12
+  %.i110.i = fsub fast float 1.000000e+00, %13
+  %.i211.i = fsub fast float 1.000000e+00, %14
   %24 = fsub fast float 1.000000e+00, %Saturate.i
   %Log.i = call float @dx.op.unary.f32(i32 23, float %24) #2  ; Log(value)
   %25 = fmul fast float %Log.i, 5.000000e+00
   %Exp.i = call float @dx.op.unary.f32(i32 21, float %25) #2  ; Exp(value)
-  %.i015.i = fmul fast float %Exp.i, %.i010.i
-  %.i116.i = fmul fast float %Exp.i, %.i112.i
-  %.i217.i = fmul fast float %Exp.i, %.i214.i
-  %.i019.i = fadd fast float %.i015.i, %12
-  %.i121.i = fadd fast float %.i116.i, %13
-  %.i223.i = fadd fast float %.i217.i, %14
-  %26 = select i1 %.i06.i, float %.i019.i, float 0.000000e+00
-  %27 = select i1 %.i17.i, float %.i121.i, float 0.000000e+00
-  %28 = select i1 %.i28.i, float %.i223.i, float 0.000000e+00
-  %.i024.i = fmul fast float %.i0.i, %26
-  %.i125.i = fmul fast float %.i0.i, %27
-  %.i226.i = fmul fast float %.i0.i, %28
-  %.i027.i = fadd fast float %.i024.i, %16
-  %.i128.i = fadd fast float %.i125.i, %17
-  %.i229.i = fadd fast float %.i226.i, %18
+  %.i012.i = fmul fast float %Exp.i, %.i09.i
+  %.i113.i = fmul fast float %Exp.i, %.i110.i
+  %.i214.i = fmul fast float %Exp.i, %.i211.i
+  %.i015.i = fadd fast float %.i012.i, %12
+  %.i116.i = fadd fast float %.i113.i, %13
+  %.i217.i = fadd fast float %.i214.i, %14
+  %26 = select i1 %.i06.i, float %.i015.i, float 0.000000e+00
+  %27 = select i1 %.i17.i, float %.i116.i, float 0.000000e+00
+  %28 = select i1 %.i28.i, float %.i217.i, float 0.000000e+00
+  %.i018.i = fmul fast float %.i0.i, %26
+  %.i119.i = fmul fast float %.i0.i, %27
+  %.i220.i = fmul fast float %.i0.i, %28
+  %.i021.i = fadd fast float %.i018.i, %16
+  %.i122.i = fadd fast float %.i119.i, %17
+  %.i223.i = fadd fast float %.i220.i, %18
   %29 = call float @dx.op.dot3.f32(i32 55, float %7, float %8, float %9, float %4, float %5, float %6) #2  ; Dot3(ax,ay,az,bx,by,bz)
-  %.i030.i = fmul fast float %.i027.i, %29
-  %.i131.i = fmul fast float %.i128.i, %29
-  %.i232.i = fmul fast float %.i229.i, %29
-  %FMax3.i = call float @dx.op.binary.f32(i32 35, float %.i030.i, float 0.000000e+00) #2  ; FMax(a,b)
-  %FMax4.i = call float @dx.op.binary.f32(i32 35, float %.i131.i, float 0.000000e+00) #2  ; FMax(a,b)
-  %FMax5.i = call float @dx.op.binary.f32(i32 35, float %.i232.i, float 0.000000e+00) #2  ; FMax(a,b)
+  %.i024.i = fmul fast float %.i021.i, %29
+  %.i125.i = fmul fast float %.i122.i, %29
+  %.i226.i = fmul fast float %.i223.i, %29
+  %FMax3.i = call float @dx.op.binary.f32(i32 35, float %.i024.i, float 0.000000e+00) #2  ; FMax(a,b)
+  %FMax4.i = call float @dx.op.binary.f32(i32 35, float %.i125.i, float 0.000000e+00) #2  ; FMax(a,b)
+  %FMax5.i = call float @dx.op.binary.f32(i32 35, float %.i226.i, float 0.000000e+00) #2  ; FMax(a,b)
   call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float %FMax3.i)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
   call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 1, float %FMax4.i)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
   call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 2, float %FMax5.i)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
@@ -180,37 +170,32 @@ attributes #2 = { nounwind }
 !dx.valver = !{!2}
 !dx.shaderModel = !{!3}
 !dx.resources = !{!4}
-!dx.typeAnnotations = !{!7, !12}
-!dx.viewIdState = !{!16}
-!dx.entryPoints = !{!17}
+!dx.typeAnnotations = !{!7}
+!dx.viewIdState = !{!11}
+!dx.entryPoints = !{!12}
 
 !0 = !{!"clang version 3.7 (tags/RELEASE_370/final)"}
 !1 = !{i32 1, i32 0}
-!2 = !{i32 1, i32 6}
+!2 = !{i32 1, i32 7}
 !3 = !{!"ps", i32 6, i32 0}
 !4 = !{null, null, !5, null}
 !5 = !{!6}
-!6 = !{i32 0, %cbPS* undef, !"cbPS", i32 0, i32 0, i32 1, i32 32, null}
-!7 = !{i32 0, %cbPS undef, !8}
-!8 = !{i32 32, !9, !10, !11}
-!9 = !{i32 6, !"diffColor", i32 3, i32 0, i32 7, i32 9}
-!10 = !{i32 6, !"specColor", i32 3, i32 16, i32 7, i32 9}
-!11 = !{i32 6, !"shininess", i32 3, i32 28, i32 7, i32 9}
-!12 = !{i32 1, void ()* @main, !13}
-!13 = !{!14}
-!14 = !{i32 0, !15, !15}
-!15 = !{}
-!16 = !{[17 x i32] [i32 15, i32 4, i32 0, i32 0, i32 0, i32 0, i32 7, i32 7, i32 7, i32 0, i32 7, i32 7, i32 7, i32 0, i32 7, i32 7, i32 7]}
-!17 = !{void ()* @main, !"main", !18, !4, null}
-!18 = !{!19, !27, null}
-!19 = !{!20, !22, !24, !25}
-!20 = !{i32 0, !"SV_Position", i8 9, i8 3, !21, i8 4, i32 1, i8 4, i32 0, i8 0, null}
-!21 = !{i32 0}
-!22 = !{i32 1, !"NORMAL", i8 9, i8 0, !21, i8 2, i32 1, i8 3, i32 1, i8 0, !23}
-!23 = !{i32 3, i32 7}
-!24 = !{i32 2, !"TEXCOORD", i8 9, i8 0, !21, i8 2, i32 1, i8 3, i32 2, i8 0, !23}
-!25 = !{i32 3, !"TEXCOORD", i8 9, i8 0, !26, i8 2, i32 1, i8 3, i32 3, i8 0, !23}
-!26 = !{i32 1}
-!27 = !{!28}
-!28 = !{i32 0, !"SV_Target", i8 9, i8 16, !21, i8 0, i32 1, i8 4, i32 0, i8 0, !29}
-!29 = !{i32 3, i32 15}
+!6 = !{i32 0, %dx.types.Handle* undef, !"cbPS", i32 0, i32 0, i32 1, i32 32, null}
+!7 = !{i32 1, void ()* @main, !8}
+!8 = !{!9}
+!9 = !{i32 0, !10, !10}
+!10 = !{}
+!11 = !{[17 x i32] [i32 15, i32 4, i32 0, i32 0, i32 0, i32 0, i32 7, i32 7, i32 7, i32 0, i32 7, i32 7, i32 7, i32 0, i32 7, i32 7, i32 7]}
+!12 = !{void ()* @main, !"main", !13, !4, null}
+!13 = !{!14, !22, null}
+!14 = !{!15, !17, !19, !20}
+!15 = !{i32 0, !"SV_Position", i8 9, i8 3, !16, i8 4, i32 1, i8 4, i32 0, i8 0, null}
+!16 = !{i32 0}
+!17 = !{i32 1, !"NORMAL", i8 9, i8 0, !16, i8 2, i32 1, i8 3, i32 1, i8 0, !18}
+!18 = !{i32 3, i32 7}
+!19 = !{i32 2, !"TEXCOORD", i8 9, i8 0, !16, i8 2, i32 1, i8 3, i32 2, i8 0, !18}
+!20 = !{i32 3, !"TEXCOORD", i8 9, i8 0, !21, i8 2, i32 1, i8 3, i32 3, i8 0, !18}
+!21 = !{i32 1}
+!22 = !{!23}
+!23 = !{i32 0, !"SV_Target", i8 9, i8 16, !16, i8 0, i32 1, i8 4, i32 0, i8 0, !24}
+!24 = !{i32 3, i32 15}

--- a/Source/Tests/Data/Expected/DetailTessellation_HS.300.essl
+++ b/Source/Tests/Data/Expected/DetailTessellation_HS.300.essl
@@ -26,27 +26,27 @@ out vec3 out_var_LIGHTVECTORTS[3];
 
 void main()
 {
-    vec3 _58_unrolled[3];
-    for (int i = 0; i < int(3); i++)
-    {
-        _58_unrolled[i] = in_var_WORLDPOS[i];
-    }
     vec3 _59_unrolled[3];
     for (int i = 0; i < int(3); i++)
     {
-        _59_unrolled[i] = in_var_NORMAL[i];
+        _59_unrolled[i] = in_var_WORLDPOS[i];
     }
-    vec2 _60_unrolled[3];
+    vec3 _60_unrolled[3];
     for (int i = 0; i < int(3); i++)
     {
-        _60_unrolled[i] = in_var_TEXCOORD0[i];
+        _60_unrolled[i] = in_var_NORMAL[i];
     }
-    vec3 _61_unrolled[3];
+    vec2 _61_unrolled[3];
     for (int i = 0; i < int(3); i++)
     {
-        _61_unrolled[i] = in_var_LIGHTVECTORTS[i];
+        _61_unrolled[i] = in_var_TEXCOORD0[i];
     }
-    VS_OUTPUT_HS_INPUT param_var_inputPatch[3] = VS_OUTPUT_HS_INPUT[](VS_OUTPUT_HS_INPUT(_58_unrolled[0], _59_unrolled[0], _60_unrolled[0], _61_unrolled[0]), VS_OUTPUT_HS_INPUT(_58_unrolled[1], _59_unrolled[1], _60_unrolled[1], _61_unrolled[1]), VS_OUTPUT_HS_INPUT(_58_unrolled[2], _59_unrolled[2], _60_unrolled[2], _61_unrolled[2]));
+    vec3 _62_unrolled[3];
+    for (int i = 0; i < int(3); i++)
+    {
+        _62_unrolled[i] = in_var_LIGHTVECTORTS[i];
+    }
+    VS_OUTPUT_HS_INPUT param_var_inputPatch[3] = VS_OUTPUT_HS_INPUT[](VS_OUTPUT_HS_INPUT(_59_unrolled[0], _60_unrolled[0], _61_unrolled[0], _62_unrolled[0]), VS_OUTPUT_HS_INPUT(_59_unrolled[1], _60_unrolled[1], _61_unrolled[1], _62_unrolled[1]), VS_OUTPUT_HS_INPUT(_59_unrolled[2], _60_unrolled[2], _61_unrolled[2], _62_unrolled[2]));
     out_var_WORLDPOS[gl_InvocationID] = param_var_inputPatch[gl_InvocationID].worldPos;
     out_var_NORMAL[gl_InvocationID] = param_var_inputPatch[gl_InvocationID].normal;
     out_var_TEXCOORD0[gl_InvocationID] = param_var_inputPatch[gl_InvocationID].texCoord;

--- a/Source/Tests/Data/Expected/DetailTessellation_HS.300.glsl
+++ b/Source/Tests/Data/Expected/DetailTessellation_HS.300.glsl
@@ -27,27 +27,27 @@ layout(location = 0) out vec3 out_var_LIGHTVECTORTS[3];
 
 void main()
 {
-    vec3 _58_unrolled[3];
-    for (int i = 0; i < int(3); i++)
-    {
-        _58_unrolled[i] = in_var_WORLDPOS[i];
-    }
     vec3 _59_unrolled[3];
     for (int i = 0; i < int(3); i++)
     {
-        _59_unrolled[i] = in_var_NORMAL[i];
+        _59_unrolled[i] = in_var_WORLDPOS[i];
     }
-    vec2 _60_unrolled[3];
+    vec3 _60_unrolled[3];
     for (int i = 0; i < int(3); i++)
     {
-        _60_unrolled[i] = in_var_TEXCOORD0[i];
+        _60_unrolled[i] = in_var_NORMAL[i];
     }
-    vec3 _61_unrolled[3];
+    vec2 _61_unrolled[3];
     for (int i = 0; i < int(3); i++)
     {
-        _61_unrolled[i] = in_var_LIGHTVECTORTS[i];
+        _61_unrolled[i] = in_var_TEXCOORD0[i];
     }
-    VS_OUTPUT_HS_INPUT param_var_inputPatch[3] = VS_OUTPUT_HS_INPUT[](VS_OUTPUT_HS_INPUT(_58_unrolled[0], _59_unrolled[0], _60_unrolled[0], _61_unrolled[0]), VS_OUTPUT_HS_INPUT(_58_unrolled[1], _59_unrolled[1], _60_unrolled[1], _61_unrolled[1]), VS_OUTPUT_HS_INPUT(_58_unrolled[2], _59_unrolled[2], _60_unrolled[2], _61_unrolled[2]));
+    vec3 _62_unrolled[3];
+    for (int i = 0; i < int(3); i++)
+    {
+        _62_unrolled[i] = in_var_LIGHTVECTORTS[i];
+    }
+    VS_OUTPUT_HS_INPUT param_var_inputPatch[3] = VS_OUTPUT_HS_INPUT[](VS_OUTPUT_HS_INPUT(_59_unrolled[0], _60_unrolled[0], _61_unrolled[0], _62_unrolled[0]), VS_OUTPUT_HS_INPUT(_59_unrolled[1], _60_unrolled[1], _61_unrolled[1], _62_unrolled[1]), VS_OUTPUT_HS_INPUT(_59_unrolled[2], _60_unrolled[2], _61_unrolled[2], _62_unrolled[2]));
     out_var_WORLDPOS[gl_InvocationID] = param_var_inputPatch[gl_InvocationID].worldPos;
     out_var_NORMAL[gl_InvocationID] = param_var_inputPatch[gl_InvocationID].normal;
     out_var_TEXCOORD0[gl_InvocationID] = param_var_inputPatch[gl_InvocationID].texCoord;

--- a/Source/Tests/Data/Expected/DetailTessellation_HS.310.essl
+++ b/Source/Tests/Data/Expected/DetailTessellation_HS.310.essl
@@ -26,27 +26,27 @@ layout(location = 0) out vec3 out_var_LIGHTVECTORTS[3];
 
 void main()
 {
-    vec3 _58_unrolled[3];
-    for (int i = 0; i < int(3); i++)
-    {
-        _58_unrolled[i] = in_var_WORLDPOS[i];
-    }
     vec3 _59_unrolled[3];
     for (int i = 0; i < int(3); i++)
     {
-        _59_unrolled[i] = in_var_NORMAL[i];
+        _59_unrolled[i] = in_var_WORLDPOS[i];
     }
-    vec2 _60_unrolled[3];
+    vec3 _60_unrolled[3];
     for (int i = 0; i < int(3); i++)
     {
-        _60_unrolled[i] = in_var_TEXCOORD0[i];
+        _60_unrolled[i] = in_var_NORMAL[i];
     }
-    vec3 _61_unrolled[3];
+    vec2 _61_unrolled[3];
     for (int i = 0; i < int(3); i++)
     {
-        _61_unrolled[i] = in_var_LIGHTVECTORTS[i];
+        _61_unrolled[i] = in_var_TEXCOORD0[i];
     }
-    VS_OUTPUT_HS_INPUT param_var_inputPatch[3] = VS_OUTPUT_HS_INPUT[](VS_OUTPUT_HS_INPUT(_58_unrolled[0], _59_unrolled[0], _60_unrolled[0], _61_unrolled[0]), VS_OUTPUT_HS_INPUT(_58_unrolled[1], _59_unrolled[1], _60_unrolled[1], _61_unrolled[1]), VS_OUTPUT_HS_INPUT(_58_unrolled[2], _59_unrolled[2], _60_unrolled[2], _61_unrolled[2]));
+    vec3 _62_unrolled[3];
+    for (int i = 0; i < int(3); i++)
+    {
+        _62_unrolled[i] = in_var_LIGHTVECTORTS[i];
+    }
+    VS_OUTPUT_HS_INPUT param_var_inputPatch[3] = VS_OUTPUT_HS_INPUT[](VS_OUTPUT_HS_INPUT(_59_unrolled[0], _60_unrolled[0], _61_unrolled[0], _62_unrolled[0]), VS_OUTPUT_HS_INPUT(_59_unrolled[1], _60_unrolled[1], _61_unrolled[1], _62_unrolled[1]), VS_OUTPUT_HS_INPUT(_59_unrolled[2], _60_unrolled[2], _61_unrolled[2], _62_unrolled[2]));
     out_var_WORLDPOS[gl_InvocationID] = param_var_inputPatch[gl_InvocationID].worldPos;
     out_var_NORMAL[gl_InvocationID] = param_var_inputPatch[gl_InvocationID].normal;
     out_var_TEXCOORD0[gl_InvocationID] = param_var_inputPatch[gl_InvocationID].texCoord;

--- a/Source/Tests/Data/Expected/DetailTessellation_HS.410.glsl
+++ b/Source/Tests/Data/Expected/DetailTessellation_HS.410.glsl
@@ -25,27 +25,27 @@ layout(location = 0) out vec3 out_var_LIGHTVECTORTS[3];
 
 void main()
 {
-    vec3 _58_unrolled[3];
-    for (int i = 0; i < int(3); i++)
-    {
-        _58_unrolled[i] = in_var_WORLDPOS[i];
-    }
     vec3 _59_unrolled[3];
     for (int i = 0; i < int(3); i++)
     {
-        _59_unrolled[i] = in_var_NORMAL[i];
+        _59_unrolled[i] = in_var_WORLDPOS[i];
     }
-    vec2 _60_unrolled[3];
+    vec3 _60_unrolled[3];
     for (int i = 0; i < int(3); i++)
     {
-        _60_unrolled[i] = in_var_TEXCOORD0[i];
+        _60_unrolled[i] = in_var_NORMAL[i];
     }
-    vec3 _61_unrolled[3];
+    vec2 _61_unrolled[3];
     for (int i = 0; i < int(3); i++)
     {
-        _61_unrolled[i] = in_var_LIGHTVECTORTS[i];
+        _61_unrolled[i] = in_var_TEXCOORD0[i];
     }
-    VS_OUTPUT_HS_INPUT param_var_inputPatch[3] = VS_OUTPUT_HS_INPUT[](VS_OUTPUT_HS_INPUT(_58_unrolled[0], _59_unrolled[0], _60_unrolled[0], _61_unrolled[0]), VS_OUTPUT_HS_INPUT(_58_unrolled[1], _59_unrolled[1], _60_unrolled[1], _61_unrolled[1]), VS_OUTPUT_HS_INPUT(_58_unrolled[2], _59_unrolled[2], _60_unrolled[2], _61_unrolled[2]));
+    vec3 _62_unrolled[3];
+    for (int i = 0; i < int(3); i++)
+    {
+        _62_unrolled[i] = in_var_LIGHTVECTORTS[i];
+    }
+    VS_OUTPUT_HS_INPUT param_var_inputPatch[3] = VS_OUTPUT_HS_INPUT[](VS_OUTPUT_HS_INPUT(_59_unrolled[0], _60_unrolled[0], _61_unrolled[0], _62_unrolled[0]), VS_OUTPUT_HS_INPUT(_59_unrolled[1], _60_unrolled[1], _61_unrolled[1], _62_unrolled[1]), VS_OUTPUT_HS_INPUT(_59_unrolled[2], _60_unrolled[2], _61_unrolled[2], _62_unrolled[2]));
     out_var_WORLDPOS[gl_InvocationID] = param_var_inputPatch[gl_InvocationID].worldPos;
     out_var_NORMAL[gl_InvocationID] = param_var_inputPatch[gl_InvocationID].normal;
     out_var_TEXCOORD0[gl_InvocationID] = param_var_inputPatch[gl_InvocationID].texCoord;

--- a/Source/Tests/Data/Expected/DetailTessellation_HS.msl
+++ b/Source/Tests/Data/Expected/DetailTessellation_HS.msl
@@ -81,13 +81,13 @@ kernel void main0(main0_in in [[stage_in]], constant type_cbMain& cbMain [[buffe
     threadgroup_barrier(mem_flags::mem_threadgroup);
     if (gl_InvocationID >= 3)
         return;
-    spvUnsafeArray<float3, 3> _58 = spvUnsafeArray<float3, 3>({ gl_in[0].in_var_WORLDPOS, gl_in[1].in_var_WORLDPOS, gl_in[2].in_var_WORLDPOS });
-    spvUnsafeArray<float3, 3> _59 = spvUnsafeArray<float3, 3>({ gl_in[0].in_var_NORMAL, gl_in[1].in_var_NORMAL, gl_in[2].in_var_NORMAL });
-    spvUnsafeArray<float2, 3> _60 = spvUnsafeArray<float2, 3>({ gl_in[0].in_var_TEXCOORD0, gl_in[1].in_var_TEXCOORD0, gl_in[2].in_var_TEXCOORD0 });
-    spvUnsafeArray<float3, 3> _61 = spvUnsafeArray<float3, 3>({ gl_in[0].in_var_LIGHTVECTORTS, gl_in[1].in_var_LIGHTVECTORTS, gl_in[2].in_var_LIGHTVECTORTS });
-    spvUnsafeArray<VS_OUTPUT_HS_INPUT, 3> _77 = spvUnsafeArray<VS_OUTPUT_HS_INPUT, 3>({ VS_OUTPUT_HS_INPUT{ _58[0], _59[0], _60[0], _61[0] }, VS_OUTPUT_HS_INPUT{ _58[1], _59[1], _60[1], _61[1] }, VS_OUTPUT_HS_INPUT{ _58[2], _59[2], _60[2], _61[2] } });
+    spvUnsafeArray<float3, 3> _59 = spvUnsafeArray<float3, 3>({ gl_in[0].in_var_WORLDPOS, gl_in[1].in_var_WORLDPOS, gl_in[2].in_var_WORLDPOS });
+    spvUnsafeArray<float3, 3> _60 = spvUnsafeArray<float3, 3>({ gl_in[0].in_var_NORMAL, gl_in[1].in_var_NORMAL, gl_in[2].in_var_NORMAL });
+    spvUnsafeArray<float2, 3> _61 = spvUnsafeArray<float2, 3>({ gl_in[0].in_var_TEXCOORD0, gl_in[1].in_var_TEXCOORD0, gl_in[2].in_var_TEXCOORD0 });
+    spvUnsafeArray<float3, 3> _62 = spvUnsafeArray<float3, 3>({ gl_in[0].in_var_LIGHTVECTORTS, gl_in[1].in_var_LIGHTVECTORTS, gl_in[2].in_var_LIGHTVECTORTS });
+    spvUnsafeArray<VS_OUTPUT_HS_INPUT, 3> _78 = spvUnsafeArray<VS_OUTPUT_HS_INPUT, 3>({ VS_OUTPUT_HS_INPUT{ _59[0], _60[0], _61[0], _62[0] }, VS_OUTPUT_HS_INPUT{ _59[1], _60[1], _61[1], _62[1] }, VS_OUTPUT_HS_INPUT{ _59[2], _60[2], _61[2], _62[2] } });
     spvUnsafeArray<VS_OUTPUT_HS_INPUT, 3> param_var_inputPatch;
-    param_var_inputPatch = _77;
+    param_var_inputPatch = _78;
     gl_out[gl_InvocationID].out_var_WORLDPOS = param_var_inputPatch[gl_InvocationID].worldPos;
     gl_out[gl_InvocationID].out_var_NORMAL = param_var_inputPatch[gl_InvocationID].normal;
     gl_out[gl_InvocationID].out_var_TEXCOORD0 = param_var_inputPatch[gl_InvocationID].texCoord;

--- a/Source/Tests/Data/Expected/Transform_VS_ColumnMajor.300.glsl
+++ b/Source/Tests/Data/Expected/Transform_VS_ColumnMajor.300.glsl
@@ -13,8 +13,10 @@ layout(std140) uniform type_cbVS
 
 in vec4 in_var_POSITION;
 
+mat4 spvWorkaroundRowMajor(mat4 wrap) { return wrap; }
+
 void main()
 {
-    gl_Position = cbVS.wvp * in_var_POSITION;
+    gl_Position = spvWorkaroundRowMajor(cbVS.wvp) * in_var_POSITION;
 }
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -153,6 +153,45 @@ stages:
     steps:
     - template: CI/AzurePipelines/ContinuousBuild.yml
 
+  - job: Windows_vc143_x64
+    pool:
+      vmImage: windows-2022
+
+    variables:
+      compiler: vc143
+      combination: 'win-$(compiler)-$(platform)-$(configuration)'
+      buildFolder: 'Build/ninja-$(combination)'
+      installCommand: 'choco install ninja'
+      testCommand: './$(buildFolder)/Bin/ShaderConductorTest.exe'
+      artifactBinaries: |
+        Bin/ShaderConductor.dll
+        Bin/ShaderConductorCmd.exe
+        Bin/dxcompiler.dll
+        Lib/ShaderConductor.lib
+
+    steps:
+    - template: CI/AzurePipelines/ContinuousBuild.yml
+
+  - job: Windows_vc143_arm64
+    pool:
+      vmImage: windows-2022
+
+    variables:
+      compiler: vc143
+      platform: arm64
+      combination: 'win-$(compiler)-$(platform)-$(configuration)'
+      buildFolder: 'Build/ninja-$(combination)'
+      installCommand: 'choco install ninja'
+      testCommand: ''
+      artifactBinaries: |
+        Bin/ShaderConductor.dll
+        Bin/ShaderConductorCmd.exe
+        Bin/dxcompiler.dll
+        Lib/ShaderConductor.lib
+
+    steps:
+    - template: CI/AzurePipelines/ContinuousBuild.yml
+
   - job: Linux_gcc7
     pool:
       vmImage: Ubuntu-18.04

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -251,14 +251,13 @@ stages:
 
   - job: macOS_10_clang
     pool:
-      vmImage: macOS 10.14
+      vmImage: macOS-10.15
 
     variables:
       compiler: clang9
       combination: 'osx-$(compiler)-$(platform)-$(configuration)'
       buildFolder: 'Build/ninja-$(combination)'
       installCommand: |
-        brew update
         brew install ninja
       testCommand: './$(buildFolder)/Bin/ShaderConductorTest'
       artifactBinaries: |


### PR DESCRIPTION
Add VS2022 support.

Note that this PR is based on https://github.com/microsoft/ShaderConductor/pull/69 . Please review that one first. This change needs to be rebased.